### PR TITLE
Adding new columns to summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ August       1333.22
 June         1444.22
 Name: AMOUNT, dtype: float64
 ```
+
+
+## TODO
+1) Tidy up three functions for filtering transction type

--- a/moneyhub-summary.py
+++ b/moneyhub-summary.py
@@ -3,70 +3,81 @@ import sys
 import argparse
 
 # define the program description
-description = 'This script will take in moneyhub statements and perform some basic analysis.'
+description = (
+    "This script will take in moneyhub statements and perform some basic analysis."
+)
 
 # initiate the parser with a description
 parser = argparse.ArgumentParser(description)
 
-#Custom arguements
+# Custom arguements
 parser.add_argument("-i", "--input-file", help="Moneyhub file location")
 parser.add_argument("-o", "--output-file", help="CSV output location")
-parser.add_argument("-s", "--summary", help="Provides a monthly summary", action="store_true")
+parser.add_argument(
+    "-s", "--summary", help="Provides a monthly summary", action="store_true"
+)
 
 args = parser.parse_args()
 
 
 transactions = pd.read_csv(args.input_file)
 
-#---------------------------------------#
+# ---------------------------------------#
 def transaction_check(row):
     """
     Check if a transaction is a transfer/outgoing/incoming
     """
-    # String comparison on value of column 
-    if 'Transfers' in row['CATEGORY GROUP']:
-        return 'Transfer'
+    # String comparison on value of column
+    if "Transfers" in row["CATEGORY GROUP"]:
+        return "Transfer"
     # If negative value then outgoing
-    elif row['AMOUNT'] < 0:
-        return 'Outgoing'
-    # If postive value then income 
-    elif row['AMOUNT'] >= 0:
-        return 'Income'
+    elif row["AMOUNT"] < 0:
+        return "Outgoing"
+    # If postive value then income
+    elif row["AMOUNT"] >= 0:
+        return "Income"
     else:
-        return 'Other'
+        return "Other"
 
-def monthly_summary(dataFrame):
-    """
-    A function that will print out the monthly summary
-    """
-    
-    summary = []
-    for index, row in dataFrame.iterrows():
-        if 'Transfer' in row['TRANSACTION TYPE']:
-            #Skip trasnfers in the count
-            continue
-        else:
-            #Append row items to summary list
-            summary.append({'DATE': row['DATE'], 'AMOUNT': row['AMOUNT'], 'TRANSACTION TYPE': row['TRANSACTION TYPE']})
-    #Turn summary list into a dataFrame
-    summary = pd.DataFrame(summary)
-    #Change date column to datetime format
-    summary['DATE'] = pd.to_datetime(summary['DATE'])
-    #Perform groupby and get sum of the values for each month
-    return summary.groupby(summary['DATE'].dt.strftime('%B'))['AMOUNT'].sum().sort_values()
 
-#---------------------------------------#
+def ignore_transfers(df):
+    """ 
+    A simple function to run inverted string contain checks on the master table and return 
+    any rows which do not contain TRANCTION TYPE = Trasfer
+    """
+    return df[~df["TRANSACTION TYPE"].str.contains("Transfer")]
+
+
+def monthly_summary(df):
+    """
+    A function that will print out the monthly summary excluding transfers
+    """
+    # Ignore SettingWithCopyWarning for now, not a concern.
+    pd.set_option("mode.chained_assignment", None)
+
+    df["DATE"] = pd.to_datetime(df["DATE"])
+    # Perform groupby and get sum of the values for each month
+    return df.groupby(df["DATE"].dt.strftime("%B"))["AMOUNT"].sum().sort_values()
+
+    # Reset chain assignment warnings
+    pd.set_option("mode.chained_assignment", Warning)
+
+
+# ---------------------------------------#
 
 # Take function return value as transaction type
-transactions['TRANSACTION TYPE'] = transactions.apply(transaction_check, axis=1)
+transactions["TRANSACTION TYPE"] = transactions.apply(transaction_check, axis=1)
 
 # Output to file if requested
 if args.output_file is True:
     transactions.to_csv(args.output_file)
 
-#Print summary if requested
+# Print summary if requested
 if args.summary is True:
-    print("The summary below adds up any transaction within each month provided they are not \"transfers\".")
+    noTrasnfers = ignore_transfers(transactions)
+    print(
+        'The summary below adds up any transaction within each month provided they are not "transfers".'
+    )
     print("This will let you see if you spent more than you earned in a month. \n")
-    print(monthly_summary(transactions))
+    print(monthly_summary(noTrasnfers))
     print("\n")


### PR DESCRIPTION

Just now the summary output works but it doesn't exactly match up with the expected values when looking at moneyhub. I'll need to look into that more.

``` bash
⇒  python3 moneyhub-summary.py -i Transaction-2019.csv  -s       
The summary below adds up any transaction within each month provided they are not "transfers".
This will let you see if you spent more than you earned in a month. 

            Income  Expenditure    Total
October    100.43     -200.78  -100.35

```

### TODO:
1) Tidy up three functions for filtering transction type
2) Fix output file argparse flag
3) Validate summary results against moneyhub